### PR TITLE
Add optional randomisation seed argument

### DIFF
--- a/blender_randomiser/install_and_enable_addons.py
+++ b/blender_randomiser/install_and_enable_addons.py
@@ -58,7 +58,8 @@ def main():
     )
 
     parser.add_argument(
-        "-seed",
+        "-s",
+        "--seed",
         metavar="N",
         type=int,
         nargs="+",

--- a/randomisation_seed.sh
+++ b/randomisation_seed.sh
@@ -4,4 +4,4 @@ source ~/.bash_profile
 # zip randomiser, launch blender and install+enable
 cd blender_randomiser
 zip -r randomiser.zip randomiser/
-blender ../sample.blend --python ./install_and_enable_addons.py -- ./randomiser.zip -seed 32
+blender ../sample.blend --python ./install_and_enable_addons.py -- ./randomiser.zip --seed 322


### PR DESCRIPTION
install_enable_addons.py script has been updated which now works with both:

- install_randomiser.sh script for installing and enable addons as previously
- randomisation_seed.sh script for installing and enable addons as well as passing optional randomisation seed argument

Related to #34 but doesn't close this issue as still have to add in a config file as an optional argument in the future