### PR TITLE
Update test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,5 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pre-commit cookiecutter pyyaml pytest pytest-cov toml
-      - name: Test with pytest
-        run: |
-          pytest
       - name: Report coverage to codecov
         uses: codecov/codecov-action@v2


### PR DESCRIPTION
Remove pytest on workflow for PRs (pytest can be run locally before pushing). Pytest needs to be run through Blender's python which cannot or is difficult to be done on a GH workflow